### PR TITLE
FEAT. 연금저축 금융 상품 검색어 기반 조회 API 구현

### DIFF
--- a/ending-credits-api/src/main/java/com/hanaro/endingcredits/endingcreditsapi/domain/product/controller/PensionSavingsController.java
+++ b/ending-credits-api/src/main/java/com/hanaro/endingcredits/endingcreditsapi/domain/product/controller/PensionSavingsController.java
@@ -5,6 +5,7 @@ import com.hanaro.endingcredits.endingcreditsapi.domain.product.dto.PensionSavin
 import com.hanaro.endingcredits.endingcreditsapi.domain.product.entities.PensionSavingsEsEntity;
 import com.hanaro.endingcredits.endingcreditsapi.domain.product.service.PensionSavingsService;
 import com.hanaro.endingcredits.endingcreditsapi.utils.apiPayload.ApiResponseEntity;
+import com.hanaro.endingcredits.endingcreditsapi.utils.apiPayload.code.status.ErrorStatus;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
@@ -47,9 +48,14 @@ public class PensionSavingsController {
             @RequestParam int areaCode) {
         try {
             List<PensionSavingsEsEntity> responseDto = pensionSavingsService.searchProducts(keyword, areaCode);
+
+            if (responseDto.isEmpty()) {
+                return ApiResponseEntity.onFailure(ErrorStatus.RECOMMEND_NOT_FOUND.getCode(), ErrorStatus.RECOMMEND_NOT_FOUND.getMessage(), null);
+            }
+
             return ApiResponseEntity.onSuccess(responseDto);
         } catch (Exception e) {
-            return ApiResponseEntity.onFailure("PRODUCT4001", "상품 목록 조회 중 오류가 발생했습니다.", null);
+            return ApiResponseEntity.onFailure(ErrorStatus.PRODUCT_NOT_FOUND.getCode(), ErrorStatus.PRODUCT_NOT_FOUND.getMessage(), null);
         }
     }
 }

--- a/ending-credits-api/src/main/java/com/hanaro/endingcredits/endingcreditsapi/domain/product/controller/PensionSavingsController.java
+++ b/ending-credits-api/src/main/java/com/hanaro/endingcredits/endingcreditsapi/domain/product/controller/PensionSavingsController.java
@@ -2,10 +2,10 @@ package com.hanaro.endingcredits.endingcreditsapi.domain.product.controller;
 
 import com.hanaro.endingcredits.endingcreditsapi.domain.product.dto.PensionSavingsListResponseDto;
 import com.hanaro.endingcredits.endingcreditsapi.domain.product.dto.PensionSavingsResponseDto;
+import com.hanaro.endingcredits.endingcreditsapi.domain.product.entities.PensionSavingsEsEntity;
 import com.hanaro.endingcredits.endingcreditsapi.domain.product.service.PensionSavingsService;
 import com.hanaro.endingcredits.endingcreditsapi.utils.apiPayload.ApiResponseEntity;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.models.responses.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -38,5 +38,18 @@ public class PensionSavingsController {
     public ApiResponseEntity<PensionSavingsResponseDto> getPensionProduct(@PathVariable(name = "productId") UUID productId){
         PensionSavingsResponseDto responseDto = pensionSavingsService.getSavingsProduct(productId);
         return ApiResponseEntity.onSuccess(responseDto);
+    }
+
+    @GetMapping("/pension-savings/search")
+    @Operation(summary = "연금저축 상품 검색어로 조회", description = "상품명으로 상품을 조회합니다.")
+    public ApiResponseEntity<List<PensionSavingsEsEntity>> searchProducts(
+            @RequestParam String keyword,
+            @RequestParam int areaCode) {
+        try {
+            List<PensionSavingsEsEntity> responseDto = pensionSavingsService.searchProducts(keyword, areaCode);
+            return ApiResponseEntity.onSuccess(responseDto);
+        } catch (Exception e) {
+            return ApiResponseEntity.onFailure("PRODUCT4001", "상품 목록 조회 중 오류가 발생했습니다.", null);
+        }
     }
 }

--- a/ending-credits-api/src/main/java/com/hanaro/endingcredits/endingcreditsapi/domain/product/entities/PensionSavingsEsEntity.java
+++ b/ending-credits-api/src/main/java/com/hanaro/endingcredits/endingcreditsapi/domain/product/entities/PensionSavingsEsEntity.java
@@ -1,0 +1,27 @@
+package com.hanaro.endingcredits.endingcreditsapi.domain.product.entities;
+
+import lombok.*;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.elasticsearch.annotations.Document;
+import org.springframework.data.elasticsearch.annotations.Field;
+import org.springframework.data.elasticsearch.annotations.FieldType;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Document(indexName = "pension_savings")
+public class PensionSavingsEsEntity {
+
+    @Id
+    private String productId;
+
+    @Field(type = FieldType.Text)
+    private String productName;
+
+    @Field(type = FieldType.Text)
+    private String productArea;
+
+    @Field(type = FieldType.Text)
+    private String company;
+}

--- a/ending-credits-api/src/main/java/com/hanaro/endingcredits/endingcreditsapi/domain/product/repository/elasticsearch/PensionSavingsSearchRepository.java
+++ b/ending-credits-api/src/main/java/com/hanaro/endingcredits/endingcreditsapi/domain/product/repository/elasticsearch/PensionSavingsSearchRepository.java
@@ -1,0 +1,15 @@
+package com.hanaro.endingcredits.endingcreditsapi.domain.product.repository.elasticsearch;
+
+import com.hanaro.endingcredits.endingcreditsapi.domain.product.entities.PensionSavingsEsEntity;
+import com.hanaro.endingcredits.endingcreditsapi.domain.product.entities.ProductArea;
+import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface PensionSavingsSearchRepository extends ElasticsearchRepository<PensionSavingsEsEntity, String> {
+    List<PensionSavingsEsEntity> findByProductNameContainingAndProductArea(
+            String productName, String productArea
+    );
+}

--- a/ending-credits-api/src/main/java/com/hanaro/endingcredits/endingcreditsapi/domain/product/service/RetirementPensionService.java
+++ b/ending-credits-api/src/main/java/com/hanaro/endingcredits/endingcreditsapi/domain/product/service/RetirementPensionService.java
@@ -139,18 +139,18 @@ public class RetirementPensionService {
                 .build();
     }
 
-    private RetirementPensionProductEntity mapToJpaEntity(RetirementPensionEsEntity esEntity) {
-        return RetirementPensionProductEntity.builder()
-                .productId(UUID.fromString(esEntity.getId()))
-                .productName(esEntity.getProductName())
-                .company(esEntity.getCompany())
-                .applyTerm(esEntity.getApplyTerm())
-                .checkDate(esEntity.getCheckDate())
-                .contractTerm(esEntity.getContractTerm())
-                .contractRate(esEntity.getContractRate())
-                .productArea(ProductArea.valueOf(String.valueOf(esEntity.getProductArea())))
-                .sysType(SysType.valueOf(String.valueOf(esEntity.getSysType())))
-                .build();
-    }
+//    private RetirementPensionProductEntity mapToJpaEntity(RetirementPensionEsEntity esEntity) {
+//        return RetirementPensionProductEntity.builder()
+//                .productId(UUID.fromString(esEntity.getId()))
+//                .productName(esEntity.getProductName())
+//                .company(esEntity.getCompany())
+//                .applyTerm(esEntity.getApplyTerm())
+//                .checkDate(esEntity.getCheckDate())
+//                .contractTerm(esEntity.getContractTerm())
+//                .contractRate(esEntity.getContractRate())
+//                .productArea(ProductArea.valueOf(String.valueOf(esEntity.getProductArea())))
+//                .sysType(SysType.valueOf(String.valueOf(esEntity.getSysType())))
+//                .build();
+//    }
 }
 

--- a/ending-credits-api/src/main/java/com/hanaro/endingcredits/endingcreditsapi/utils/config/RetirementPensionDataInitializer.java
+++ b/ending-credits-api/src/main/java/com/hanaro/endingcredits/endingcreditsapi/utils/config/RetirementPensionDataInitializer.java
@@ -1,11 +1,17 @@
 package com.hanaro.endingcredits.endingcreditsapi.utils.config;
 
+//import com.hanaro.endingcredits.endingcreditsapi.domain.product.mapper.PensionSavingsProductMapper;
+import com.hanaro.endingcredits.endingcreditsapi.domain.product.repository.elasticsearch.PensionSavingsSearchRepository;
+import com.hanaro.endingcredits.endingcreditsapi.domain.product.repository.jpa.PensionSavingsJpaRepository;
 import com.hanaro.endingcredits.endingcreditsapi.domain.product.service.PensionSavingsService;
 import com.hanaro.endingcredits.endingcreditsapi.domain.product.service.RetirementPensionService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.ApplicationRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
 
 import java.util.List;
 
@@ -13,7 +19,34 @@ import java.util.List;
 @RequiredArgsConstructor
 public class RetirementPensionDataInitializer {
 
+    private final PensionSavingsService pensionSavingsService;
     private final RetirementPensionService retirementPensionService;
+
+    @Value("${api.key}")
+    private String apiKey;
+
+    private static final String API_URL = "https://www.fss.or.kr/openapi/api/psProdList.json";
+
+    @Bean
+    public ApplicationRunner initPensionSavingsData() {
+        return args -> {
+            List<Integer> areaCodes = List.of(1, 3, 4, 5);
+
+            for (int areaCode : areaCodes) {
+                int year = 2024;
+                int quarter = 3;
+
+                String requestUrl = UriComponentsBuilder.fromHttpUrl(API_URL)
+                        .queryParam("key", apiKey)
+                        .queryParam("year", year)
+                        .queryParam("quarter", quarter)
+                        .queryParam("areaCode", areaCode)
+                        .toUriString();
+
+                pensionSavingsService.fetchAndSavePensionProducts(requestUrl, areaCode);
+            }
+        };
+    }
 
     @Bean
     public ApplicationRunner initRetirementPensionData() {


### PR DESCRIPTION
1. Elasticsearch 연동

 - Elasticsearch를 사용하여 금융 상품을 효율적으로 검색
 - Elasticsearch의 쿼리 방식에 맞게 카테고리 기반 검색

2. API 설계

- `GET` /product/pension-savings/search: 검색어 기반 상품 검색