### PR TITLE
FIX. 회원가입 시 간편 비밀번호 수집 수정

### DIFF
--- a/ending-credits-api/src/main/java/com/hanaro/endingcredits/endingcreditsapi/domain/auth/dto/SignUpDto.java
+++ b/ending-credits-api/src/main/java/com/hanaro/endingcredits/endingcreditsapi/domain/auth/dto/SignUpDto.java
@@ -33,7 +33,4 @@ public class SignUpDto {
 
     @NotBlank
     private String email;
-
-    @NotBlank
-    private String simplePassword;
 }

--- a/ending-credits-api/src/main/java/com/hanaro/endingcredits/endingcreditsapi/domain/member/entities/MemberEntity.java
+++ b/ending-credits-api/src/main/java/com/hanaro/endingcredits/endingcreditsapi/domain/member/entities/MemberEntity.java
@@ -36,7 +36,7 @@ public class MemberEntity {
     @Column(nullable = false)
     private String password;
 
-    @Column(nullable = false)
+    @Column
     private String simplePassword;
 
     @Column(nullable = false)


### PR DESCRIPTION
 - 회원가입에서 SignupDTO에서 간편 비밀번호 항목 제거
 - 간편 비밀번호 API를 분리해서 사용하는 것으로 변경되어 해당 내용 반영