### PR TITLE
FIX. 연금저축 상품, 퇴직연금 기업 상세 조회 시 페이징 처리

### DIFF
--- a/ending-credits-api/src/main/java/com/hanaro/endingcredits/endingcreditsapi/domain/product/controller/PensionSavingsController.java
+++ b/ending-credits-api/src/main/java/com/hanaro/endingcredits/endingcreditsapi/domain/product/controller/PensionSavingsController.java
@@ -1,15 +1,14 @@
 package com.hanaro.endingcredits.endingcreditsapi.domain.product.controller;
 
-import com.hanaro.endingcredits.endingcreditsapi.domain.product.dto.PensionSavingsDetailResponseDto;
-import com.hanaro.endingcredits.endingcreditsapi.domain.product.dto.PensionSavingsEstimateDto;
-import com.hanaro.endingcredits.endingcreditsapi.domain.product.dto.PensionSavingsListResponseDto;
-import com.hanaro.endingcredits.endingcreditsapi.domain.product.dto.PensionSavingsResponseComparisonDto;
+import com.hanaro.endingcredits.endingcreditsapi.domain.product.dto.*;
 import com.hanaro.endingcredits.endingcreditsapi.domain.product.entities.PensionSavingsSearchItems;
 import com.hanaro.endingcredits.endingcreditsapi.domain.product.service.PensionSavingsService;
 import com.hanaro.endingcredits.endingcreditsapi.utils.apiPayload.ApiResponseEntity;
 import com.hanaro.endingcredits.endingcreditsapi.utils.apiPayload.code.status.ErrorStatus;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -24,8 +23,8 @@ public class PensionSavingsController {
 
     @GetMapping("/all")
     @Operation(summary = "연금저축 상품 전체 목록 조회", description = "상품 연금저축 상품 목록을 조회합니다.")
-    public ApiResponseEntity<List<PensionSavingsListResponseDto>> getAllPensionProductList() {
-        List<PensionSavingsListResponseDto> responseDto = pensionSavingsService.getAllSavingsProductList();
+    public ApiResponseEntity<SliceResponse<PensionSavingsListResponseDto>> getAllPensionProductList(@PageableDefault(size = 8) Pageable pageable) {
+        SliceResponse<PensionSavingsListResponseDto> responseDto = pensionSavingsService.getAllSavingsProductList(pageable);
         return ApiResponseEntity.onSuccess(responseDto);
     }
 

--- a/ending-credits-api/src/main/java/com/hanaro/endingcredits/endingcreditsapi/domain/product/controller/RetirementPensionController.java
+++ b/ending-credits-api/src/main/java/com/hanaro/endingcredits/endingcreditsapi/domain/product/controller/RetirementPensionController.java
@@ -3,6 +3,7 @@ package com.hanaro.endingcredits.endingcreditsapi.domain.product.controller;
 import com.hanaro.endingcredits.endingcreditsapi.domain.product.dto.RetirementPensionCompanySummaryDto;
 import com.hanaro.endingcredits.endingcreditsapi.domain.product.dto.RetirementPensionDetailResponseDto;
 import com.hanaro.endingcredits.endingcreditsapi.domain.product.dto.RetirementPensionFeeComparisonDto;
+import com.hanaro.endingcredits.endingcreditsapi.domain.product.dto.SliceResponse;
 import com.hanaro.endingcredits.endingcreditsapi.domain.product.entities.RetirementPensionSearchItems;
 import com.hanaro.endingcredits.endingcreditsapi.domain.product.service.RetirementPensionService;
 import com.hanaro.endingcredits.endingcreditsapi.utils.apiPayload.ApiResponseEntity;
@@ -10,6 +11,9 @@ import com.hanaro.endingcredits.endingcreditsapi.utils.apiPayload.code.status.Er
 import com.hanaro.endingcredits.endingcreditsapi.utils.apiPayload.exception.handler.FinanceHandler;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -44,9 +48,9 @@ public class RetirementPensionController {
 
     @GetMapping("/all")
     @Operation(summary = "퇴직연금 기업 전체 목록 조회", description = "퇴직연금 기업 전체 목록을 조회합니다.")
-    public ApiResponseEntity<List<RetirementPensionCompanySummaryDto>> getAllPensionProducts() {
+    public ApiResponseEntity<SliceResponse<RetirementPensionCompanySummaryDto>> getAllPensionProducts(@PageableDefault(size = 8) Pageable pageable) {
         try {
-            List<RetirementPensionCompanySummaryDto> allProducts = retirementPensionService.getAllCompany();
+            SliceResponse<RetirementPensionCompanySummaryDto> allProducts = retirementPensionService.getAllCompany(pageable);
             return ApiResponseEntity.onSuccess(allProducts);
         } catch (Exception e) {
             return ApiResponseEntity.onFailure(ErrorStatus.YIELD_NOT_FOUND.getCode(), ErrorStatus.YIELD_NOT_FOUND.getMessage(), null);

--- a/ending-credits-api/src/main/java/com/hanaro/endingcredits/endingcreditsapi/domain/product/dto/SliceResponse.java
+++ b/ending-credits-api/src/main/java/com/hanaro/endingcredits/endingcreditsapi/domain/product/dto/SliceResponse.java
@@ -1,0 +1,23 @@
+package com.hanaro.endingcredits.endingcreditsapi.domain.product.dto;
+
+import lombok.Getter;
+import org.springframework.data.domain.Slice;
+
+import java.util.List;
+
+@Getter
+public class SliceResponse<T> {
+    private final List<T> content;
+    private final int currentPage;
+    private final int size;
+    private final boolean first;
+    private final boolean last;
+
+    public SliceResponse(Slice<T> sliceContent){
+        this.content=sliceContent.getContent();
+        this.currentPage=sliceContent.getNumber();
+        this.size=sliceContent.getSize();
+        this.first=sliceContent.isFirst();
+        this.last=sliceContent.isLast();
+    }
+}

--- a/ending-credits-api/src/main/java/com/hanaro/endingcredits/endingcreditsapi/domain/product/repository/jpa/PensionSavingsJpaRepository.java
+++ b/ending-credits-api/src/main/java/com/hanaro/endingcredits/endingcreditsapi/domain/product/repository/jpa/PensionSavingsJpaRepository.java
@@ -2,6 +2,8 @@ package com.hanaro.endingcredits.endingcreditsapi.domain.product.repository.jpa;
 
 import com.hanaro.endingcredits.endingcreditsapi.domain.product.entities.PensionSavingsProductEntity;
 import com.hanaro.endingcredits.endingcreditsapi.domain.product.entities.ProductArea;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -10,6 +12,7 @@ import java.util.UUID;
 
 @Repository
 public interface PensionSavingsJpaRepository extends JpaRepository<PensionSavingsProductEntity, UUID> {
+    Slice<PensionSavingsProductEntity> findAllBy(Pageable pageable);
     List<PensionSavingsProductEntity> findByProductArea(ProductArea productArea);
     List<PensionSavingsProductEntity> findByCompany(String company);
 }

--- a/ending-credits-api/src/main/java/com/hanaro/endingcredits/endingcreditsapi/domain/product/repository/jpa/RetirementPensionJpaRepository.java
+++ b/ending-credits-api/src/main/java/com/hanaro/endingcredits/endingcreditsapi/domain/product/repository/jpa/RetirementPensionJpaRepository.java
@@ -1,7 +1,11 @@
 package com.hanaro.endingcredits.endingcreditsapi.domain.product.repository.jpa;
 
+import com.hanaro.endingcredits.endingcreditsapi.domain.product.entities.PensionSavingsProductEntity;
 import com.hanaro.endingcredits.endingcreditsapi.domain.product.entities.RetirementPensionCompanyEntity;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
@@ -9,6 +13,7 @@ import java.util.UUID;
 
 @Repository
 public interface RetirementPensionJpaRepository extends JpaRepository<RetirementPensionCompanyEntity, UUID> {
+    @Query("SELECT DISTINCT r FROM RetirementPensionCompanyEntity r")
+    Slice<RetirementPensionCompanyEntity> findAllBy(Pageable pageable);
     Optional<RetirementPensionCompanyEntity> findByCompany(String company);
-//    List<RetirementPensionYieldEntity> findByProductAreaAndSysType(ProductArea productArea, SysType sysType);
 }

--- a/ending-credits-api/src/main/java/com/hanaro/endingcredits/endingcreditsapi/domain/product/service/PensionSavingsService.java
+++ b/ending-credits-api/src/main/java/com/hanaro/endingcredits/endingcreditsapi/domain/product/service/PensionSavingsService.java
@@ -9,6 +9,8 @@ import com.hanaro.endingcredits.endingcreditsapi.utils.apiPayload.exception.hand
 import com.hanaro.endingcredits.endingcreditsapi.utils.mapper.ProductMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.client.RestTemplate;
@@ -67,16 +69,18 @@ public class PensionSavingsService {
     }
 
     @Transactional(readOnly = true)
-    public List<PensionSavingsListResponseDto> getAllSavingsProductList() {
+    public SliceResponse<PensionSavingsListResponseDto> getAllSavingsProductList(Pageable pageable) {
+        Slice<PensionSavingsProductEntity> pensionSavingsProducts = pensionProductRepository.findAllBy(pageable);
 
-        return pensionProductRepository.findAll()
-                .stream()
-                .map(product -> PensionSavingsListResponseDto.builder()
+        Slice<PensionSavingsListResponseDto> mappedProducts = pensionSavingsProducts.map(product ->
+                PensionSavingsListResponseDto.builder()
                         .productId(product.getProductId())
                         .productName(product.getProductName())
                         .company(product.getCompany())
-                        .build())
-                .collect(Collectors.toList());
+                        .build()
+        );
+
+        return new SliceResponse<>(mappedProducts);
     }
 
     @Transactional(readOnly = true)

--- a/ending-credits-api/src/main/java/com/hanaro/endingcredits/endingcreditsapi/domain/product/service/RetirementPensionService.java
+++ b/ending-credits-api/src/main/java/com/hanaro/endingcredits/endingcreditsapi/domain/product/service/RetirementPensionService.java
@@ -9,6 +9,8 @@ import com.hanaro.endingcredits.endingcreditsapi.utils.apiPayload.exception.hand
 import com.hanaro.endingcredits.endingcreditsapi.utils.mapper.ProductMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.client.RestTemplate;
@@ -198,22 +200,17 @@ public class RetirementPensionService {
 
 
     @Transactional(readOnly = true)
-    public List<RetirementPensionCompanySummaryDto> getAllCompany() {
-        return retirementPensionJpaRepository.findAll()
-                .stream()
-                .collect(Collectors.toMap(
-                        companyYield -> companyYield.getCompany(),
-                        Function.identity(),
-                        (existing, replacement) -> existing
-                ))
-                .values()
-                .stream()
-                .map(companyYield -> RetirementPensionCompanySummaryDto.builder()
-                        .companyId(companyYield.getCompanyId())
-                        .company(companyYield.getCompany())
-                        .build()
-                )
-                .collect(Collectors.toList());
+    public SliceResponse<RetirementPensionCompanySummaryDto> getAllCompany(Pageable pageable) {
+        Slice<RetirementPensionCompanyEntity> retirementPensionCompanies = retirementPensionJpaRepository.findAllBy(pageable);
+
+        Slice<RetirementPensionCompanySummaryDto> mappedCompanies = retirementPensionCompanies.map(companyYield ->
+                        RetirementPensionCompanySummaryDto.builder()
+                                .companyId(companyYield.getCompanyId())
+                                .company(companyYield.getCompany())
+                                .build()
+                );
+
+        return new SliceResponse<>(mappedCompanies);
     }
 
     @Transactional(readOnly = true)


### PR DESCRIPTION
프론트엔드 연동 작업 중 페이징 처리가 필요하다 판단하여 기존 API 수정이 필요

- `GET` /product/annuity/all : 퇴직연금 기업 전체 조회
- `GET` /product/pension-savings/all : 연금저축 상품 전체 조회

상세 내용
- 페이징 처리 작업 추가
- 전체 조회에서 비즈니스 로직 변경
- 에러 테스트 및 확인