### PR TITLE
FEAT. 신분증 OCR 기능 

### DIFF
--- a/ending-credits-api/src/main/java/com/hanaro/endingcredits/endingcreditsapi/domain/auth/controller/AuthController.java
+++ b/ending-credits-api/src/main/java/com/hanaro/endingcredits/endingcreditsapi/domain/auth/controller/AuthController.java
@@ -134,7 +134,6 @@ public class AuthController {
     @PostMapping("/id-card")
     public ApiResponseEntity<IdCardDto> recognizeIdCard(@RequestParam("file") MultipartFile file) {
         IdCardDto idCard = authService.recognizeIdCard(file);
-        System.out.println("idCard = " + idCard.getName());
         return ApiResponseEntity.onSuccess(idCard);
     }
 

--- a/ending-credits-api/src/main/java/com/hanaro/endingcredits/endingcreditsapi/domain/auth/controller/AuthController.java
+++ b/ending-credits-api/src/main/java/com/hanaro/endingcredits/endingcreditsapi/domain/auth/controller/AuthController.java
@@ -14,6 +14,7 @@ import org.apache.http.HttpHeaders;
 
 import lombok.RequiredArgsConstructor;
 import io.swagger.v3.oas.annotations.Operation;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.UUID;
 
@@ -127,6 +128,14 @@ public class AuthController {
         } catch (MemberHandler e) {
             return ApiResponseEntity.onFailure(e.getErrorReason().getCode(), e.getErrorReason().getMessage(), null);
         }
+    }
+
+    @Operation(summary = "신분증 OCR")
+    @PostMapping("/id-card")
+    public ApiResponseEntity<IdCardDto> recognizeIdCard(@RequestParam("file") MultipartFile file) {
+        IdCardDto idCard = authService.recognizeIdCard(file);
+        System.out.println("idCard = " + idCard.getName());
+        return ApiResponseEntity.onSuccess(idCard);
     }
 
     @Operation(summary = "본인인증 SMS 전송")

--- a/ending-credits-api/src/main/java/com/hanaro/endingcredits/endingcreditsapi/domain/auth/dto/IdCardDto.java
+++ b/ending-credits-api/src/main/java/com/hanaro/endingcredits/endingcreditsapi/domain/auth/dto/IdCardDto.java
@@ -1,0 +1,13 @@
+package com.hanaro.endingcredits.endingcreditsapi.domain.auth.dto;
+
+import lombok.*;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class IdCardDto {
+    private String name;
+    private String address;
+    private String idNumber;
+}

--- a/ending-credits-api/src/main/java/com/hanaro/endingcredits/endingcreditsapi/domain/auth/service/AuthService.java
+++ b/ending-credits-api/src/main/java/com/hanaro/endingcredits/endingcreditsapi/domain/auth/service/AuthService.java
@@ -4,6 +4,7 @@ import com.hanaro.endingcredits.endingcreditsapi.domain.auth.dto.*;
 import com.hanaro.endingcredits.endingcreditsapi.domain.member.dto.MemberDto;
 import com.hanaro.endingcredits.endingcreditsapi.domain.member.entities.MemberEntity;
 import com.hanaro.endingcredits.endingcreditsapi.domain.member.repository.MemberRepository;
+import com.hanaro.endingcredits.endingcreditsapi.utils.adapter.OCRPort;
 import com.hanaro.endingcredits.endingcreditsapi.utils.apiPayload.code.status.ErrorStatus;
 import com.hanaro.endingcredits.endingcreditsapi.utils.apiPayload.exception.InvalidJwtException;
 import com.hanaro.endingcredits.endingcreditsapi.utils.apiPayload.exception.handler.JwtHandler;
@@ -23,6 +24,7 @@ import org.springframework.util.MultiValueMap;
 import org.springframework.stereotype.Service;
 import org.springframework.http.*;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.Date;
@@ -39,6 +41,7 @@ public class AuthService {
     private final RestTemplate restTemplate;
     private final MemberMapper memberMapper;
     private final JwtProvider jwtProvider;
+    private final OCRPort ocrPort;
 
     @Value("${kakao.client-id}")
     private String kakaoClientId;
@@ -254,5 +257,11 @@ public class AuthService {
     public void removeExpiredCodes() {
         long currentTime = System.currentTimeMillis();
         cerificationCodes.entrySet().removeIf(entry -> entry.getValue().getExpiryTime() < currentTime);
+    }
+
+    public IdCardDto recognizeIdCard(MultipartFile file) {
+        System.out.println("AuthService.recognizeIdCard");
+        return ocrPort.recognizeIdCard(file);
+
     }
 }

--- a/ending-credits-api/src/main/java/com/hanaro/endingcredits/endingcreditsapi/domain/auth/service/AuthService.java
+++ b/ending-credits-api/src/main/java/com/hanaro/endingcredits/endingcreditsapi/domain/auth/service/AuthService.java
@@ -260,7 +260,6 @@ public class AuthService {
     }
 
     public IdCardDto recognizeIdCard(MultipartFile file) {
-        System.out.println("AuthService.recognizeIdCard");
         return ocrPort.recognizeIdCard(file);
 
     }

--- a/ending-credits-api/src/main/java/com/hanaro/endingcredits/endingcreditsapi/utils/adapter/OCRPort.java
+++ b/ending-credits-api/src/main/java/com/hanaro/endingcredits/endingcreditsapi/utils/adapter/OCRPort.java
@@ -1,4 +1,14 @@
 package com.hanaro.endingcredits.endingcreditsapi.utils.adapter;
 
+import com.hanaro.endingcredits.endingcreditsapi.domain.auth.dto.IdCardDto;
+import org.springframework.web.multipart.MultipartFile;
+
 public interface OCRPort {
+    /**
+     * 신분증을 인식하여 정보 추출
+     * 신분증: 주민등록증, 운전면허증
+     * @param file 신분증 이미지 파일
+     * @return 이름, 주소, 주민등록번호
+     */
+    IdCardDto recognizeIdCard(MultipartFile file);
 }

--- a/ending-credits-api/src/main/java/com/hanaro/endingcredits/endingcreditsapi/utils/adapter/clovaAdapter/ClovaOCRAdapter.java
+++ b/ending-credits-api/src/main/java/com/hanaro/endingcredits/endingcreditsapi/utils/adapter/clovaAdapter/ClovaOCRAdapter.java
@@ -1,7 +1,19 @@
 package com.hanaro.endingcredits.endingcreditsapi.utils.adapter.clovaAdapter;
 
+import com.hanaro.endingcredits.endingcreditsapi.domain.auth.dto.IdCardDto;
+import com.hanaro.endingcredits.endingcreditsapi.utils.adapter.OCRPort;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
 
 @Component
-public class ClovaOCRAdapter {
+@RequiredArgsConstructor
+public class ClovaOCRAdapter implements OCRPort {
+
+    private final ClovaOCRProvider clovaOCRProvider;
+
+    @Override
+    public IdCardDto recognizeIdCard(MultipartFile file) {
+        return clovaOCRProvider.recognizeIdCard(file);
+    }
 }

--- a/ending-credits-api/src/main/java/com/hanaro/endingcredits/endingcreditsapi/utils/adapter/clovaAdapter/ClovaOCRProvider.java
+++ b/ending-credits-api/src/main/java/com/hanaro/endingcredits/endingcreditsapi/utils/adapter/clovaAdapter/ClovaOCRProvider.java
@@ -1,7 +1,99 @@
 package com.hanaro.endingcredits.endingcreditsapi.utils.adapter.clovaAdapter;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hanaro.endingcredits.endingcreditsapi.domain.auth.dto.IdCardDto;
+import com.hanaro.endingcredits.endingcreditsapi.utils.adapter.dto.clova.OCR.ClovaDLResponseDto;
+import com.hanaro.endingcredits.endingcreditsapi.utils.adapter.dto.clova.OCR.ClovaICResponseDto;
+import com.hanaro.endingcredits.endingcreditsapi.utils.adapter.dto.clova.OCR.tmp._ClovaDriversLicenseResponseDto;
+import com.hanaro.endingcredits.endingcreditsapi.utils.adapter.dto.clova.OCR.tmp._ClovaRegistrationCardResultDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
 import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 
 @Component
+@RequiredArgsConstructor
 public class ClovaOCRProvider {
+
+    @Value("${clova.ocr.invoke-url}")
+    private String invokeUrl;
+
+    @Value("${clova.ocr.secret-key}")
+    private String secretKey;
+
+    private final RestTemplate restTemplate;
+    private final ObjectMapper objectMapper;
+
+    private String extractFileExtension(MultipartFile file) {
+        String originalFilename = file.getOriginalFilename();
+        return Objects.requireNonNull(originalFilename).substring(originalFilename.lastIndexOf('.') + 1);
+    }
+
+    public IdCardDto recognizeIdCard(MultipartFile file) {
+        System.out.println("ClovaOCRProvider.recognizeIdCard");
+        String fileExtension = extractFileExtension(file);
+
+        // Create the request body
+        Map<String, Object> message = new HashMap<>();
+        message.put("version", "V2");
+        message.put("requestId", "UUID");
+        message.put("timestamp", 0);
+        Map<String, String> image = new HashMap<>();
+        image.put("format", fileExtension);
+        image.put("name", "IdCard");
+        message.put("images", new Map[]{image});
+
+        // Create the headers
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("X-OCR-SECRET", secretKey);
+        headers.setContentType(MediaType.MULTIPART_FORM_DATA);
+
+        // Create the form data
+        MultiValueMap<String, Object> formData = new LinkedMultiValueMap<>();
+        formData.add("message", message);
+        formData.add("file", file.getResource());
+
+        // Create the HttpEntity
+        HttpEntity<MultiValueMap<String, Object>> entity = new HttpEntity<>(formData, headers);
+
+        // Send the POST request
+        String url = invokeUrl + "/document/id-card";
+        ResponseEntity<Object> response = restTemplate.postForEntity(url, entity, Object.class);
+        System.out.println("response.getBody() = " + response.getBody());
+
+        // Parse the response and map to IdCardDto
+        if (response.getBody() != null) {
+            Map<String, Object> responseBody = objectMapper.convertValue(response.getBody(), Map.class);
+            String idType = (String) ((Map<String, Object>) ((Map<String, Object>) ((Map<String, Object>) ((List<Object>) responseBody.get("images")).get(0)).get("idCard")).get("result")).get("idtype");
+            System.out.println("idType = " + idType);
+            if ("ID Card".equals(idType)) {
+                ClovaICResponseDto clovaICResponseDto = objectMapper.convertValue(responseBody, ClovaICResponseDto.class);
+                return new IdCardDto(
+                        clovaICResponseDto.getImages().get(0).getIdCard().getResult().getIc().getName().get(0).getFormatted().getValue(),
+                        clovaICResponseDto.getImages().get(0).getIdCard().getResult().getIc().getAddress().get(0).getFormatted().getValue(),
+                        clovaICResponseDto.getImages().get(0).getIdCard().getResult().getIc().getPersonalNum().get(0).getFormatted().getValue()
+                );
+            }
+            else if ("Driver's License".equals(idType)) {
+                ClovaDLResponseDto clovaDLResponseDto = objectMapper.convertValue(responseBody, ClovaDLResponseDto.class);
+                return new IdCardDto(
+                        clovaDLResponseDto.getImages().get(0).getIdCard().getResult().getDl().getName().get(0).getFormatted().getValue(),
+                        clovaDLResponseDto.getImages().get(0).getIdCard().getResult().getDl().getAddress().get(0).getFormatted().getValue(),
+                        clovaDLResponseDto.getImages().get(0).getIdCard().getResult().getDl().getPersonalNum().get(0).getFormatted().getValue()
+                );
+
+            }
+        }
+
+        return null;
+    }
 }

--- a/ending-credits-api/src/main/java/com/hanaro/endingcredits/endingcreditsapi/utils/adapter/dto/clova/OCR/ClovaDLDto.java
+++ b/ending-credits-api/src/main/java/com/hanaro/endingcredits/endingcreditsapi/utils/adapter/dto/clova/OCR/ClovaDLDto.java
@@ -1,0 +1,25 @@
+package com.hanaro.endingcredits.endingcreditsapi.utils.adapter.dto.clova.OCR;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ClovaDLDto {
+    private List<Object> type;
+    private List<Object> num;
+    private List<ClovaIdCardDetailDto> name;
+    private List<ClovaIdCardDetailDto> personalNum;
+    private List<ClovaIdCardDetailDto> address;
+    private List<Object> renewStartDate;
+    private List<Object> renewEndDate;
+    private List<Object> code;
+    private List<Object> issueDate;
+    private List<Object> authority;
+}

--- a/ending-credits-api/src/main/java/com/hanaro/endingcredits/endingcreditsapi/utils/adapter/dto/clova/OCR/ClovaDLIdCardDto.java
+++ b/ending-credits-api/src/main/java/com/hanaro/endingcredits/endingcreditsapi/utils/adapter/dto/clova/OCR/ClovaDLIdCardDto.java
@@ -1,0 +1,15 @@
+package com.hanaro.endingcredits.endingcreditsapi.utils.adapter.dto.clova.OCR;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ClovaDLIdCardDto {
+    private Object meta;
+    private ClovaDLResultDto result;
+}

--- a/ending-credits-api/src/main/java/com/hanaro/endingcredits/endingcreditsapi/utils/adapter/dto/clova/OCR/ClovaDLImageDto.java
+++ b/ending-credits-api/src/main/java/com/hanaro/endingcredits/endingcreditsapi/utils/adapter/dto/clova/OCR/ClovaDLImageDto.java
@@ -1,0 +1,19 @@
+package com.hanaro.endingcredits.endingcreditsapi.utils.adapter.dto.clova.OCR;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ClovaDLImageDto {
+    private String uid;
+    private String name;
+    private String inferResult;
+    private String message;
+    private Object validationResult;
+    private ClovaDLIdCardDto idCard;
+}

--- a/ending-credits-api/src/main/java/com/hanaro/endingcredits/endingcreditsapi/utils/adapter/dto/clova/OCR/ClovaDLResponseDto.java
+++ b/ending-credits-api/src/main/java/com/hanaro/endingcredits/endingcreditsapi/utils/adapter/dto/clova/OCR/ClovaDLResponseDto.java
@@ -1,0 +1,19 @@
+package com.hanaro.endingcredits.endingcreditsapi.utils.adapter.dto.clova.OCR;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ClovaDLResponseDto {
+    private String version;
+    private String requestId;
+    private Long timestamp;
+    private List<ClovaDLImageDto> images;
+}

--- a/ending-credits-api/src/main/java/com/hanaro/endingcredits/endingcreditsapi/utils/adapter/dto/clova/OCR/ClovaDLResultDto.java
+++ b/ending-credits-api/src/main/java/com/hanaro/endingcredits/endingcreditsapi/utils/adapter/dto/clova/OCR/ClovaDLResultDto.java
@@ -1,0 +1,17 @@
+package com.hanaro.endingcredits.endingcreditsapi.utils.adapter.dto.clova.OCR;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ClovaDLResultDto {
+    private Boolean isConfident;
+    private ClovaDLDto dl;
+    private Object rois;
+    private String idType;
+}

--- a/ending-credits-api/src/main/java/com/hanaro/endingcredits/endingcreditsapi/utils/adapter/dto/clova/OCR/ClovaICDto.java
+++ b/ending-credits-api/src/main/java/com/hanaro/endingcredits/endingcreditsapi/utils/adapter/dto/clova/OCR/ClovaICDto.java
@@ -1,0 +1,20 @@
+package com.hanaro.endingcredits.endingcreditsapi.utils.adapter.dto.clova.OCR;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ClovaICDto {
+    private List<ClovaIdCardDetailDto> name;
+    private List<ClovaIdCardDetailDto> personalNum;
+    private List<ClovaIdCardDetailDto> address;
+    private List<Object> issueDate;
+    private List<Object> authority;
+}

--- a/ending-credits-api/src/main/java/com/hanaro/endingcredits/endingcreditsapi/utils/adapter/dto/clova/OCR/ClovaICIdCardDto.java
+++ b/ending-credits-api/src/main/java/com/hanaro/endingcredits/endingcreditsapi/utils/adapter/dto/clova/OCR/ClovaICIdCardDto.java
@@ -1,0 +1,15 @@
+package com.hanaro.endingcredits.endingcreditsapi.utils.adapter.dto.clova.OCR;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ClovaICIdCardDto {
+    private Object meta;
+    private ClovaICResultDto result;
+}

--- a/ending-credits-api/src/main/java/com/hanaro/endingcredits/endingcreditsapi/utils/adapter/dto/clova/OCR/ClovaICImageDto.java
+++ b/ending-credits-api/src/main/java/com/hanaro/endingcredits/endingcreditsapi/utils/adapter/dto/clova/OCR/ClovaICImageDto.java
@@ -1,0 +1,19 @@
+package com.hanaro.endingcredits.endingcreditsapi.utils.adapter.dto.clova.OCR;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ClovaICImageDto {
+    private String uid;
+    private String name;
+    private String inferResult;
+    private String message;
+    private Object validationResult;
+    private ClovaICIdCardDto idCard;
+}

--- a/ending-credits-api/src/main/java/com/hanaro/endingcredits/endingcreditsapi/utils/adapter/dto/clova/OCR/ClovaICResponseDto.java
+++ b/ending-credits-api/src/main/java/com/hanaro/endingcredits/endingcreditsapi/utils/adapter/dto/clova/OCR/ClovaICResponseDto.java
@@ -1,0 +1,19 @@
+package com.hanaro.endingcredits.endingcreditsapi.utils.adapter.dto.clova.OCR;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ClovaICResponseDto {
+    private String version;
+    private String requestId;
+    private Long timestamp;
+    private List<ClovaICImageDto> images;
+}

--- a/ending-credits-api/src/main/java/com/hanaro/endingcredits/endingcreditsapi/utils/adapter/dto/clova/OCR/ClovaICResultDto.java
+++ b/ending-credits-api/src/main/java/com/hanaro/endingcredits/endingcreditsapi/utils/adapter/dto/clova/OCR/ClovaICResultDto.java
@@ -1,0 +1,17 @@
+package com.hanaro.endingcredits.endingcreditsapi.utils.adapter.dto.clova.OCR;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ClovaICResultDto {
+    private Boolean isConfident;
+    private ClovaICDto ic;
+    private Object rois;
+    private String idType;
+}

--- a/ending-credits-api/src/main/java/com/hanaro/endingcredits/endingcreditsapi/utils/adapter/dto/clova/OCR/ClovaIdCardDetailDto.java
+++ b/ending-credits-api/src/main/java/com/hanaro/endingcredits/endingcreditsapi/utils/adapter/dto/clova/OCR/ClovaIdCardDetailDto.java
@@ -1,0 +1,29 @@
+package com.hanaro.endingcredits.endingcreditsapi.utils.adapter.dto.clova.OCR;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ClovaIdCardDetailDto {
+    private String text;
+    private Formatted formatted;
+    private String keyText;
+    private double confidenceScore;
+    private List<Object> boundingPolys;
+    private List<Object> maskingPolys;
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Formatted {
+        private String value;
+    }
+}


### PR DESCRIPTION
신분증 OCR 기능 개발

인식 가능 신분증 종류
- 주민등록증
- 운전면허증

설정 파일 (노션 반영 완료)
- OCR 관련 설정값
- 이미지 용량 크기로 인한 설정


이미지 파일의 경우 아래와 같이 요청을 보내면 됨
- curl
`curl --location 'http://localhost:8080/auth/id-card' \
--form 'file=@"postman-cloud:///1efd85df-c676-4f50-8e8c-fa89088ec4d7"'`
- postman 
<img width="815" alt="image" src="https://github.com/user-attachments/assets/86ef0ac8-e371-4c7e-b8e7-ec97260f7d7b" />

ps. 신분증 이미지는 별도로 저장되고 있지 않기 때문에 신분증 원본 이미지로 편하게 전송하셔도 괜찮아요 =)
